### PR TITLE
Set SOVERSION of the shared library to 0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,8 @@ endif()
 
 if(FLATBUFFERS_BUILD_SHAREDLIB)
   add_library(flatbuffers_shared SHARED ${FlatBuffers_Library_SRCS})
-  set_target_properties(flatbuffers_shared PROPERTIES OUTPUT_NAME flatbuffers)
+  set_target_properties(flatbuffers_shared 
+      PROPERTIES OUTPUT_NAME flatbuffers SOVERSION 0)
 endif()
 
 function(compile_flatbuffers_schema_to_cpp SRC_FBS)


### PR DESCRIPTION
A buildsystem require the non-versioned shared lib file to be a symlink